### PR TITLE
Enable build / lint from application root path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+application/ormconfig.json

--- a/application/millage-client/package.json
+++ b/application/millage-client/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "start": "craco start",
-    "build": "craco build",
+    "build": "craco build && mv build ../millage-server/dist",
     "test": "craco test",
     "eject": "react-scripts eject",
     "lint": "eslint './src/**/*.{ts,tsx,js,jsx}'",

--- a/application/millage-server/src/main.ts
+++ b/application/millage-server/src/main.ts
@@ -6,9 +6,11 @@ import {join} from 'path';
 
 async function bootstrap() {
   const appOptions = {cors: true};
-  const app = await NestFactory.create<NestExpressApplication>(AppModule, appOptions);
+  const app = await NestFactory.create<NestExpressApplication>(
+      AppModule,
+      appOptions);
   app.useStaticAssets(join(__dirname, '..', 'public'));
-  app.setBaseViewsDir(join(__dirname, '..', 'views'));
+  app.useStaticAssets(join(__dirname, '..', 'dist'));
 
   // Swagger Options
   const options = new DocumentBuilder()

--- a/application/package.json
+++ b/application/package.json
@@ -11,7 +11,10 @@
       "start": "yarn workspace millage-server start && yarn workspace millage-client start",
       "server-start": "yarn workspace millage-server start",
       "server-start:watch": "yarn workspace millage-server start:watch",
-      "client-start": "yarn workspace millage-client start"
+      "client-start": "yarn workspace millage-client start",
+      "build": "yarn workspace millage-client build",
+      "lint": "yarn workspace millage-client lint && yarn workspace millage-server lint",
+      "lint:fix": "yarn workspace millage-client lint:fix && yarn workspace millage-server lint:fix"
     }
   }
   


### PR DESCRIPTION
- application 폴더에서 react app을 빌드한 후 nodejs 서버를 실행시킬 수 있도록 스크립트 추가
- ormconfig 를 gitignore에 추가

