### PR TITLE
chore: #130 Change Paths as constants

### DIFF
--- a/application/millage-client/src/constants/index.ts
+++ b/application/millage-client/src/constants/index.ts
@@ -1,3 +1,5 @@
+export * from './paths';
+
 export const TRUE = 'true';
 export const FALSE = 'false';
 
@@ -5,6 +7,3 @@ export const FALSE = 'false';
 export const NORMAL = 'NORMAL';
 export const POLL = 'POLL';
 export const RECRUIT = 'RECRUIT';
-
-export const REGISTER_PATH = '/register';
-export const ROOT_PATH = '/';

--- a/application/millage-client/src/constants/paths.ts
+++ b/application/millage-client/src/constants/paths.ts
@@ -1,0 +1,11 @@
+export const ROOT_PATH = '/';
+
+export const SIGNIN_PATH = '/login';
+export const REGISTER_PATH = '/register';
+export const SIGNUP_PATH = '/register/user';
+
+export const SCHEDULE_PATH = '/schedule';
+export const DM_PATH = '/dm';
+export const CREATE_POST_PATH = '/create';
+export const CREATE_BOARD_PATH = '/create-board';
+export const BOARD_VIEW_PATH = '/board/:boardId';

--- a/application/millage-client/src/pages/App.tsx
+++ b/application/millage-client/src/pages/App.tsx
@@ -6,15 +6,21 @@ import Signup from '@pages/Signup';
 import Main from '@pages/Main';
 import './App.css';
 import UnitList from '@components/UnitList';
+import {
+  SIGNIN_PATH,
+  ROOT_PATH,
+  SIGNUP_PATH,
+  REGISTER_PATH,
+} from '@constants';
 
 function App() {
   return (
     <>
       <Switch>
-        <Route exact path='/login' component={SignIn} />
-        <Route exact path="/register" component={UnitList} />
-        <Route exact path="/register/user" component={Signup} />
-        <Route path='/' component={Main} />
+        <Route exact path={SIGNIN_PATH} component={SignIn} />
+        <Route exact path={REGISTER_PATH} component={UnitList} />
+        <Route exact path={SIGNUP_PATH} component={Signup} />
+        <Route path={ROOT_PATH} component={Main} />
       </Switch>
       <Footer/>
     </>

--- a/application/millage-client/src/pages/Main/index.tsx
+++ b/application/millage-client/src/pages/Main/index.tsx
@@ -10,6 +10,14 @@ import Intro from '@pages/Intro';
 import MainPage from './MainPage';
 import DM from '@pages/DM';
 import BoardViewPage from '@pages/boards/BoardView';
+import {
+  BOARD_VIEW_PATH,
+  CREATE_BOARD_PATH,
+  CREATE_POST_PATH,
+  DM_PATH,
+  ROOT_PATH,
+  SCHEDULE_PATH,
+} from '@constants';
 
 const Main = () => {
   const dispatch = useDispatch();
@@ -24,12 +32,12 @@ const Main = () => {
       <>
         <Header />
         <Switch>
-          <Route exact path='/' component={MainPage} />
-          <Route path='/schedule' component={Schedule} />
-          <Route path='/dm' component={DM} />
-          <Route path='/create' component={CreatePostPage} />
-          <Route path='/create-board' component={CreateBoardPage} />
-          <Route path='/board/:boardId' component={BoardViewPage} />
+          <Route exact path={ROOT_PATH} component={MainPage} />
+          <Route path={SCHEDULE_PATH} component={Schedule} />
+          <Route path={DM_PATH} component={DM} />
+          <Route path={CREATE_POST_PATH} component={CreatePostPage} />
+          <Route path={CREATE_BOARD_PATH} component={CreateBoardPage} />
+          <Route path={BOARD_VIEW_PATH} component={BoardViewPage} />
         </Switch>
       </>
     );

--- a/application/millage-client/src/pages/boards/BoardView/index.tsx
+++ b/application/millage-client/src/pages/boards/BoardView/index.tsx
@@ -3,6 +3,7 @@ import {useHistory, useParams} from 'react-router';
 import {useBoard} from '@hooks/board';
 import {Link} from 'react-router-dom';
 import PostListItem from '@components/boards/PostListItem';
+import {ROOT_PATH} from '@constants';
 
 type BoardViewParams = {
   boardId: string;
@@ -18,7 +19,7 @@ function BoardViewPage() {
   const {loading, data, error} = curBoardState;
   const history = useHistory();
   if (error) {
-    history.replace('/');
+    history.replace(ROOT_PATH);
   }
 
   return (


### PR DESCRIPTION
pathname이 literal string으로 작성될 경우 오타 등으로 오류가 발생할 수 있고,
어떤 페이지를 라우팅하는 지 명확하지 못한 경우가 있습니다.
따라서 이를 constant로 관리하도록 변경하였습니다.

Resolves #130
See Also #129