### PR TITLE
Refactor: Separate APIs from consts & add board's

### DIFF
--- a/application/millage-client/src/constants/APIs.ts
+++ b/application/millage-client/src/constants/APIs.ts
@@ -1,0 +1,7 @@
+export const SERVER         = 'https://millage.ml/api';    // 'http://localhost:3000/api'
+export const SOCKET_SERVER  = 'https://millage.ml'; // 'http://localhost:3001'
+
+export const BOARD_API          = `${SERVER}/board`;
+export const GET_BOARD_LIST_API = `${BOARD_API}/list`;
+export const CREATE_BOARD_API   = `${BOARD_API}/create`;
+export const GET_BOARD_API      = BOARD_API;

--- a/application/millage-client/src/constants/index.ts
+++ b/application/millage-client/src/constants/index.ts
@@ -1,4 +1,5 @@
 export * from './paths';
+export * from './APIs';
 
 export const TRUE = 'true';
 export const FALSE = 'false';
@@ -7,6 +8,3 @@ export const FALSE = 'false';
 export const NORMAL = 'NORMAL';
 export const POLL = 'POLL';
 export const RECRUIT = 'RECRUIT';
-
-export const SERVER = 'https://millage.ml/api';    // 'http://localhost:3000/api'
-export const SOCKET_SERVER = 'https://millage.ml'; // 'http://localhost:3001'


### PR DESCRIPTION
constants/index 에 있는 것보다 분류하고 관리하기 편하다고 생각하여,
Backend API url만을 모아놓은 constants 파일을 생성하였습니다.